### PR TITLE
Replace primary artifact with shaded artifact

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -31,7 +31,7 @@ Run
 After building the artifacts, the executables can be found in the `target`
 directories. Their filenames have the following format:
 
-    <module>-<version>-jar-with-dependencies.jar
+    <module>-<version>.jar
 
 Run an executable with Java:
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,8 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>2.3</version>
           <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
             <minimizeJar>true</minimizeJar>
-            <shadedArtifactAttached>true</shadedArtifactAttached>
-            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
           </configuration>
           <executions>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,14 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.6</version>
+          <configuration>
+            <forceCreation>true</forceCreation> <!-- MSHADE-126 -->
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.9.1</version>
         </plugin>


### PR DESCRIPTION
An application module, as opposed to a library module, is never used as a dependency of another module. Thus, the only interesting artifact of an application module is the shaded artifact.

Configure `maven-shade-plugin` to attach the shaded artifact as the primary artifact of the module.