### PR TITLE
Add execution with price to order book reconstruction

### DIFF
--- a/parity-top/src/main/java/org/jvirtanen/parity/top/Market.java
+++ b/parity-top/src/main/java/org/jvirtanen/parity/top/Market.java
@@ -85,9 +85,33 @@ public class Market {
         if (order == null)
             return;
 
+        execute(orderId, order, quantity, order.getPrice());
+    }
+
+    /**
+     * Execute a quantity of an order in the order book. If the remaining
+     * quantity reaches zero, the order is deleted from the order book.
+     *
+     * <p>A Trade event and a BBO event are triggered.</p>
+     *
+     * <p>If the order identifier is unknown, do nothing.</p>
+     *
+     * @param orderId the order identifier
+     * @param quantity the executed quantity
+     * @param price the execution price
+     */
+    public void execute(long orderId, long quantity, long price) {
+        Order order = orders.get(orderId);
+        if (order == null)
+            return;
+
+        execute(orderId, order, quantity, price);
+    }
+
+    private void execute(long orderId, Order order, long quantity, long price) {
         OrderBook book = order.getOrderBook();
 
-        listener.trade(book.getInstrument(), order.getSide(), order.getPrice(), quantity);
+        listener.trade(book.getInstrument(), order.getSide(), price, quantity);
 
         if (quantity < order.getRemainingQuantity()) {
             order.reduce(quantity);

--- a/parity-top/src/test/java/org/jvirtanen/parity/top/MarketTest.java
+++ b/parity-top/src/test/java/org/jvirtanen/parity/top/MarketTest.java
@@ -63,6 +63,21 @@ public class MarketTest {
     }
 
     @Test
+    public void executionWithPrice() {
+        market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
+        market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
+        market.add(INSTRUMENT, 3, Side.SELL, 1002,  50);
+        market.execute(2, 200, 1000);
+
+        Event bboAfterBid      = new BBO(INSTRUMENT, 999, 100,    0,   0);
+        Event bboAfterFirstAsk = new BBO(INSTRUMENT, 999, 100, 1001, 200);
+        Event trade            = new Trade(INSTRUMENT, Side.SELL, 1000, 200);
+        Event bboAfterTrade    = new BBO(INSTRUMENT, 999, 100, 1002,  50);
+
+        assertEquals(asList(bboAfterBid, bboAfterFirstAsk, trade, bboAfterTrade), events.collect());
+    }
+
+    @Test
     public void partialExecution() {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);


### PR DESCRIPTION
Add execution with price to the order book reconstruction so that it supports market data protocols with such functionality.