### PR TITLE
Add cancel reporting to trading system

### DIFF
--- a/parity-net/doc/PMR.md
+++ b/parity-net/doc/PMR.md
@@ -58,6 +58,19 @@ Side | Description
 `S`  | Sell
 
 
+### Cancel
+
+A Cancel message indicates that an order has been canceled in part of fully.
+
+Name              | Length | Type   | Notes
+------------------|--------|--------|------
+Message Type      |      1 | Text   | `X`
+Timestamp         |      8 | Number |
+Username          |      8 | Text   |
+Order Number      |      8 | Number |
+Canceled Quantity |      4 | Number |
+
+
 ### Trade
 
 A Trade message indicates that a trade has taken place. The match number and

--- a/parity-net/src/main/java/org/jvirtanen/parity/net/pmr/PMR.java
+++ b/parity-net/src/main/java/org/jvirtanen/parity/net/pmr/PMR.java
@@ -13,8 +13,9 @@ public class PMR {
     private PMR() {
     }
 
-    static final byte MESSAGE_TYPE_ORDER = 'O';
-    static final byte MESSAGE_TYPE_TRADE = 'T';
+    static final byte MESSAGE_TYPE_ORDER  = 'O';
+    static final byte MESSAGE_TYPE_CANCEL = 'X';
+    static final byte MESSAGE_TYPE_TRADE  = 'T';
 
     public static final byte BUY  = 'B';
     public static final byte SELL = 'S';
@@ -58,6 +59,33 @@ public class PMR {
             buffer.putLong(instrument);
             putUnsignedInt(buffer, quantity);
             putUnsignedInt(buffer, price);
+        }
+    }
+
+    /**
+     * A Cancel message.
+     */
+    public static class Cancel implements Message {
+        public long timestamp;
+        public long username;
+        public long orderNumber;
+        public long canceledQuantity;
+
+        @Override
+        public void get(ByteBuffer buffer) {
+            timestamp        = buffer.getLong();
+            username         = buffer.getLong();
+            orderNumber      = buffer.getLong();
+            canceledQuantity = getUnsignedInt(buffer);
+        }
+
+        @Override
+        public void put(ByteBuffer buffer) {
+            buffer.put(MESSAGE_TYPE_CANCEL);
+            buffer.putLong(timestamp);
+            buffer.putLong(username);
+            buffer.putLong(orderNumber);
+            putUnsignedInt(buffer, canceledQuantity);
         }
     }
 

--- a/parity-net/src/main/java/org/jvirtanen/parity/net/pmr/PMRListener.java
+++ b/parity-net/src/main/java/org/jvirtanen/parity/net/pmr/PMRListener.java
@@ -18,6 +18,14 @@ public interface PMRListener {
     void order(Order message) throws IOException;
 
     /**
+     * Receive a Cancel message.
+     *
+     * @param message the message
+     * @throws IOException if an I/O error occurs
+     */
+    void cancel(Cancel message) throws IOException;
+
+    /**
      * Receive a Trade message.
      *
      * @param message the message

--- a/parity-net/src/main/java/org/jvirtanen/parity/net/pmr/PMRParser.java
+++ b/parity-net/src/main/java/org/jvirtanen/parity/net/pmr/PMRParser.java
@@ -11,8 +11,9 @@ import org.jvirtanen.nassau.MessageListener;
  */
 public class PMRParser implements MessageListener {
 
-    private Order order;
-    private Trade trade;
+    private Order  order;
+    private Cancel cancel;
+    private Trade  trade;
 
     private PMRListener listener;
 
@@ -22,8 +23,9 @@ public class PMRParser implements MessageListener {
      * @param listener the message listener
      */
     public PMRParser(PMRListener listener) {
-        this.order = new Order();
-        this.trade = new Trade();
+        this.order  = new Order();
+        this.cancel = new Cancel();
+        this.trade  = new Trade();
 
         this.listener = listener;
     }
@@ -35,6 +37,9 @@ public class PMRParser implements MessageListener {
         switch (messageType) {
         case MESSAGE_TYPE_ORDER:
             order(buffer);
+            break;
+        case MESSAGE_TYPE_CANCEL:
+            cancel(buffer);
             break;
         case MESSAGE_TYPE_TRADE:
             trade(buffer);
@@ -48,6 +53,12 @@ public class PMRParser implements MessageListener {
         order.get(buffer);
 
         listener.order(order);
+    }
+
+    private void cancel(ByteBuffer buffer) throws IOException {
+        cancel.get(buffer);
+
+        listener.cancel(cancel);
     }
 
     private void trade(ByteBuffer buffer) throws IOException {

--- a/parity-reporter/src/main/java/org/jvirtanen/parity/reporter/MarketReportListener.java
+++ b/parity-reporter/src/main/java/org/jvirtanen/parity/reporter/MarketReportListener.java
@@ -14,6 +14,10 @@ abstract class MarketReportListener implements PMRListener {
     public void order(PMR.Order message) {
     }
 
+    @Override
+    public void cancel(PMR.Cancel message) {
+    }
+
     protected void printf(String format, Object... args) {
         System.out.printf(Locale.US, format, args);
     }

--- a/parity-system/src/main/java/org/jvirtanen/parity/system/MarketReporting.java
+++ b/parity-system/src/main/java/org/jvirtanen/parity/system/MarketReporting.java
@@ -15,8 +15,9 @@ import org.jvirtanen.parity.net.pmr.PMR;
 
 class MarketReporting {
 
-    private PMR.Order order;
-    private PMR.Trade trade;
+    private PMR.Order  order;
+    private PMR.Cancel cancel;
+    private PMR.Trade  trade;
 
     private MoldUDP64Server transport;
 
@@ -29,8 +30,9 @@ class MarketReporting {
     private ByteBuffer buffer;
 
     private MarketReporting(MoldUDP64Server transport, MoldUDP64RequestServer requestTransport) {
-        this.order = new PMR.Order();
-        this.trade = new PMR.Trade();
+        this.order  = new PMR.Order();
+        this.cancel = new PMR.Cancel();
+        this.trade  = new PMR.Trade();
 
         this.transport = transport;
 
@@ -86,6 +88,15 @@ class MarketReporting {
         order.price       = price;
 
         send(order);
+    }
+
+    public void cancel(long username, long orderNumber, long canceledQuantity) {
+        cancel.timestamp        = timestamp();
+        cancel.username         = username;
+        cancel.orderNumber      = orderNumber;
+        cancel.canceledQuantity = canceledQuantity;
+
+        send(cancel);
     }
 
     public void trade(long matchNumber, long instrument, long quantity, long price, long buyer,

--- a/parity-system/src/main/java/org/jvirtanen/parity/system/MatchingEngine.java
+++ b/parity-system/src/main/java/org/jvirtanen/parity/system/MatchingEngine.java
@@ -145,6 +145,8 @@ class MatchingEngine {
                 if (remainingQuantity == 0 && handling != null)
                     release(handling);
             }
+
+            marketReporting.cancel(handling.getSession().getUsername(), orderNumber, canceledQuantity);
         }
 
     }


### PR DESCRIPTION
While it is possible to track canceled orders per market participant by matching messages in the market data protocol with messages in the market reporting protocol, this is quite difficult.

Change the market reporting protocol to report canceled orders as well.