### PR TITLE
Add SoupBinTCP support to stock ticker and trade reporter

### DIFF
--- a/parity-reporter/etc/devel.conf
+++ b/parity-reporter/etc/devel.conf
@@ -1,3 +1,7 @@
+#
+# Receive trade reports using NASDAQ MoldUDP64 as the underlying transport
+# protocol.
+#
 trade-report {
   multicast-interface = 127.0.0.1
   multicast-group     = 224.0.0.1
@@ -5,3 +9,14 @@ trade-report {
   request-address     = 127.0.0.1
   request-port        = 5002
 }
+
+# #
+# # Receive trade reports using NASDAQ SoupBinTCP as the underlying transport
+# # protocol.
+# #
+# trade-report {
+#   address  = 127.0.0.1
+#   port     = 5001
+#   username = parity
+#   password = parity
+# }

--- a/parity-ticker/etc/devel.conf
+++ b/parity-ticker/etc/devel.conf
@@ -1,3 +1,7 @@
+#
+# Receive market data using NASDAQ MoldUDP64 as the underlying transport
+# protocol.
+#
 market-data {
   multicast-interface = 127.0.0.1
   multicast-group     = 224.0.0.1
@@ -5,6 +9,17 @@ market-data {
   request-address     = 127.0.0.1
   request-port        = 4002
 }
+
+# #
+# # Receive market data using NASDAQ SoupBinTCP as the underlying transport
+# # protocol.
+# #
+# market-data {
+#   address  = 127.0.0.1
+#   port     = 4001
+#   username = parity
+#   password = parity
+# }
 
 instruments = [
   FOO,

--- a/parity-ticker/src/main/java/org/jvirtanen/parity/ticker/StockTicker.java
+++ b/parity-ticker/src/main/java/org/jvirtanen/parity/ticker/StockTicker.java
@@ -12,9 +12,11 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.util.List;
 import org.jvirtanen.config.Configs;
+import org.jvirtanen.nassau.MessageListener;
 import org.jvirtanen.parity.net.pmd.PMDParser;
 import org.jvirtanen.parity.top.Market;
 import org.jvirtanen.parity.util.MoldUDP64;
+import org.jvirtanen.parity.util.SoupBinTCP;
 
 class StockTicker {
 
@@ -43,12 +45,6 @@ class StockTicker {
     }
 
     private static void main(Config config, boolean taq) throws IOException {
-        NetworkInterface multicastInterface = Configs.getNetworkInterface(config, "market-data.multicast-interface");
-        InetAddress      multicastGroup     = Configs.getInetAddress(config, "market-data.multicast-group");
-        int              multicastPort      = Configs.getPort(config, "market-data.multicast-port");
-        InetAddress      requestAddress     = Configs.getInetAddress(config, "market-data.request-address");
-        int              requestPort        = Configs.getPort(config, "market-data.request-port");
-
         List<String> instruments = config.getStringList("instruments");
 
         MarketDataListener listener = taq ? new TAQFormat() : new DisplayFormat(instruments);
@@ -60,8 +56,27 @@ class StockTicker {
 
         MarketDataProcessor processor = new MarketDataProcessor(market, listener);
 
-        MoldUDP64.receive(multicastInterface, new InetSocketAddress(multicastGroup, multicastPort),
-                new InetSocketAddress(requestAddress, requestPort), new PMDParser(processor));
+        main(config, new PMDParser(processor));
+    }
+
+    private static void main(Config config, MessageListener listener) throws IOException {
+        if (config.hasPath("market-data.multicast-interface")) {
+            NetworkInterface multicastInterface = Configs.getNetworkInterface(config, "market-data.multicast-interface");
+            InetAddress      multicastGroup     = Configs.getInetAddress(config, "market-data.multicast-group");
+            int              multicastPort      = Configs.getPort(config, "market-data.multicast-port");
+            InetAddress      requestAddress     = Configs.getInetAddress(config, "market-data.request-address");
+            int              requestPort        = Configs.getPort(config, "market-data.request-port");
+
+            MoldUDP64.receive(multicastInterface, new InetSocketAddress(multicastGroup, multicastPort),
+                    new InetSocketAddress(requestAddress, requestPort), listener);
+        } else {
+            InetAddress address  = Configs.getInetAddress(config, "market-data.address");
+            int         port     = Configs.getPort(config, "market-data.port");
+            String      username = config.getString("market-data.username");
+            String      password = config.getString("market-data.password");
+
+            SoupBinTCP.receive(new InetSocketAddress(address, port), username, password, listener);
+        }
     }
 
 }

--- a/parity-util/src/main/java/org/jvirtanen/parity/util/SoupBinTCP.java
+++ b/parity-util/src/main/java/org/jvirtanen/parity/util/SoupBinTCP.java
@@ -1,0 +1,94 @@
+package org.jvirtanen.parity.util;
+
+import static org.jvirtanen.nassau.soupbintcp.SoupBinTCP.*;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.Selector;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+import org.jvirtanen.nassau.MessageListener;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPClient;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPClientStatusListener;
+
+/**
+ * This class contains utility methods for SoupBinTCP.
+ */
+public class SoupBinTCP {
+
+    private static final int TIMEOUT = 1000;
+
+    private SoupBinTCP() {
+    }
+
+    /**
+     * Receive messages.
+     *
+     * @param address the address
+     * @param username the username
+     * @param password the password
+     * @param listener the message listener
+     * @throws IOException if an I/O error occurs
+     */
+    public static void receive(InetSocketAddress address, String username,
+            String password, MessageListener listener) throws IOException {
+        SocketChannel channel = SocketChannel.open();
+
+        channel.connect(address);
+        channel.configureBlocking(false);
+
+        SoupBinTCPClientStatusListener statusListener = new SoupBinTCPClientStatusListener() {
+
+            @Override
+            public void heartbeatTimeout() throws IOException {
+                throw new IOException("Heartbeat timeout");
+            }
+
+            @Override
+            public void loginAccepted(LoginAccepted payload) {
+            }
+
+            @Override
+            public void loginRejected(LoginRejected payload) throws IOException {
+                throw new IOException("Login rejected");
+            }
+
+            @Override
+            public void endOfSession() {
+            }
+
+        };
+
+        SoupBinTCPClient client = new SoupBinTCPClient(channel, listener, statusListener);
+
+        LoginRequest message = new LoginRequest();
+
+        message.username = username;
+        message.password = password;
+        message.requestedSession = "";
+        message.requestedSequenceNumber = 0;
+
+        client.login(message);
+
+        receive(client);
+    }
+
+    private static void receive(SoupBinTCPClient client) throws IOException {
+        Selector selector = Selector.open();
+
+        client.getChannel().register(selector, SelectionKey.OP_READ);
+
+        while (true) {
+            selector.select(TIMEOUT);
+
+            if (!selector.selectedKeys().isEmpty()) {
+                client.receive();
+
+                selector.selectedKeys().clear();
+            }
+
+            client.keepAlive();
+        }
+    }
+
+}


### PR DESCRIPTION
NASDAQ MoldUDP64 1.00, used by the market data protocol and the market reporting protocol, is based on multicast transmission, which is often not possible on cloud infrastructure.

Add support for NASDAQ SoupBinTCP 3.00 to the stock ticker and trade reporter. Unlike MoldUDP64, SoupBinTCP is based on unicast transmission.

While the trading system will support only MoldUDP64, a gateway can be used to bridge the MoldUDP64 protocol to the SoupBinTCP protocol.