### PR TITLE
Add modification to order book reconstruction

### DIFF
--- a/parity-top/src/main/java/org/jvirtanen/parity/top/Market.java
+++ b/parity-top/src/main/java/org/jvirtanen/parity/top/Market.java
@@ -80,6 +80,36 @@ public class Market {
     }
 
     /**
+     * Modify an order in the order book. The order will retain its time
+     * priority. If the new size is zero, the order is deleted from the
+     * order book.
+     *
+     * <p>A BBO event is triggered if the top of the book changes.</p>
+     *
+     * <p>If the order identifier is unknown, do nothing.</p>
+     *
+     * @param orderId the order identifier
+     * @param size the new size
+     */
+    public void modify(long orderId, long size) {
+        Order order = orders.get(orderId);
+        if (order == null)
+            return;
+
+        boolean onBestLevel = order.isOnBestLevel();
+
+        if (size > 0) {
+            order.setRemainingQuantity(size);
+        } else {
+            orders.remove(orderId);
+            order.delete();
+        }
+
+        if (onBestLevel)
+            order.getOrderBook().bbo(listener);
+    }
+
+    /**
      * Execute a quantity of an order in the order book. If the remaining
      * quantity reaches zero, the order is deleted from the order book.
      *

--- a/parity-top/src/main/java/org/jvirtanen/parity/top/Order.java
+++ b/parity-top/src/main/java/org/jvirtanen/parity/top/Order.java
@@ -55,6 +55,10 @@ public class Order {
         return remainingQuantity;
     }
 
+    void setRemainingQuantity(long remainingQuantity) {
+        this.remainingQuantity = remainingQuantity;
+    }
+
     boolean isOnBestLevel() {
         return parent.isBestLevel();
     }

--- a/parity-top/src/test/java/org/jvirtanen/parity/top/MarketTest.java
+++ b/parity-top/src/test/java/org/jvirtanen/parity/top/MarketTest.java
@@ -48,6 +48,19 @@ public class MarketTest {
     }
 
     @Test
+    public void modification() {
+        market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
+        market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);
+        market.modify(2, 100);
+
+        Event bboAfterBid          = new BBO(INSTRUMENT, 999, 100,    0,   0);
+        Event bboAfterAsk          = new BBO(INSTRUMENT, 999, 100, 1001, 200);
+        Event bboAfterModification = new BBO(INSTRUMENT, 999, 100, 1001, 100);
+
+        assertEquals(asList(bboAfterBid, bboAfterAsk, bboAfterModification), events.collect());
+    }
+
+    @Test
     public void execution() {
         market.add(INSTRUMENT, 1, Side.BUY,   999, 100);
         market.add(INSTRUMENT, 2, Side.SELL, 1001, 200);


### PR DESCRIPTION
Add modification to the order book reconstruction so that it supports market data protocols that represent quantity changes in execution and cancellation in terms of absolute values instead of relative ones.